### PR TITLE
Sending and receiving shares as a group to mimic broadcast msgs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,5 +2,3 @@ pub mod frost;
 pub mod schnorr;
 pub mod util;
 pub mod vss;
-
-


### PR DESCRIPTION
The interface now sends & receives hashmaps of all the shares instead of assuming these will be sent individually to all the parties. This better reflects the fact that these will be shared via broadcast messages.
It's assumed that the functions to serialize & deserialize these maps will handle encrypting/decrypting the v of each (k,v) with the public key for k.