### PR TITLE
Pubkey for each point calculated from public poly instead of passed.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -142,7 +142,7 @@ fn main() {
         total_sig_time += sig_time.as_micros();
 
         println!("Signature (R,z) = \n({},{})", sig.R, sig.z);
-        assert!(sig.verify(&sig_agg.key, &msg));
+        assert!(sig.verify(sig_agg.get_public_key(), &msg));
 
         // this resets one party's nonces assuming it went down and needed to regenerate
         if sig_ct == 3 {


### PR DESCRIPTION
Before the public key for the secret share was getting passed along w/ each signature and the signature was compared against that.

I decided that it made more sense to use the polynomial commitments to calculate these. This uses information that the SA already has so it (slightly) reduces the bandwidth. But it also provides more accountability to make sure they're using the right key.

I put this in the main branch. But I don't know if it will play nicely with my other PR so maybe I will update that one separately?