### PR TITLE
Multiple parties per signer for FROST v1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,4 +62,4 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: -- -D warnings
+          args: -- -D warnings -A clippy::op-ref

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,4 +62,4 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: -- -D warnings -A clippy::op-ref
+          args: -- -D warnings -A clippy::op-ref -A clippy::needless-range-loop

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,10 +15,6 @@ secp256k1-math = { git = "https://github.com/Trust-Machines/rust-secp256k1-math"
 serde = { version = "1.0", features = ["derive"] }
 sha3 = "0.10.5"
 
-[dev-dependencies]
-json = "0.12.4"
-serde_json = "1.0"
-
 [lib]
 path = "src/lib.rs"    # The source file of the target.
 crate-type = ["lib"]   # The crate types to generate.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,13 +6,18 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-secp256k1-math = { git = "https://github.com/Trust-Machines/rust-secp256k1-math", rev = "d5785ac180e15c7a3e48da3bd0d1baa12fd7adc5"  }
-hashbrown = "0.12"
+hashbrown = { version = "0.13", features = ["serde"] }
 hex = "0.4.3"
 num-traits = "0.2"
-polynomial = "0.2.4"
+polynomial = { git = "https://github.com/Trust-Machines/polynomial-rs", rev = "3e2fafa6e85dec5b84006374ffe1cc83473182e5", features = ["serde"] }
 rand_core = "0.5"
+secp256k1-math = { git = "https://github.com/Trust-Machines/rust-secp256k1-math", rev = "ad35f79ce18d67fdd3c11697066b28ea38c5fbde" }
+serde = { version = "1.0", features = ["derive"] }
 sha3 = "0.10.5"
+
+[dev-dependencies]
+json = "0.12.4"
+serde_json = "1.0"
 
 [lib]
 path = "src/lib.rs"    # The source file of the target.

--- a/src/common.rs
+++ b/src/common.rs
@@ -71,7 +71,7 @@ impl Signature {
     // verify: R' = z * G + -c * publicKey, pass if R' == R
     #[allow(non_snake_case)]
     pub fn verify(&self, public_key: &Point, msg: &[u8]) -> bool {
-        let c = challenge(&public_key, &self.R, &msg);
+        let c = challenge(public_key, &self.R, msg);
         let R = &self.z * G + (-c) * public_key;
 
         println!("Verification R = {}", R);

--- a/src/common.rs
+++ b/src/common.rs
@@ -1,5 +1,6 @@
 use core::ops::Add;
 use num_traits::Zero;
+use rand_core::{CryptoRng, RngCore};
 use secp256k1_math::{
     point::{Point, G},
     scalar::Scalar,
@@ -26,6 +27,15 @@ impl PolyCommitment {
 pub struct Nonce {
     pub d: Scalar,
     pub e: Scalar,
+}
+
+impl Nonce {
+    pub fn random<RNG: RngCore + CryptoRng>(rng: &mut RNG) -> Self {
+        Self {
+            d: Scalar::random(rng),
+            e: Scalar::random(rng),
+        }
+    }
 }
 
 impl Zero for Nonce {

--- a/src/common.rs
+++ b/src/common.rs
@@ -54,7 +54,7 @@ impl PublicNonce {
 
 // TODO: Remove public key from here
 // The SA should get that as usual
-#[derive(Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize)]
 pub struct SignatureShare {
     pub id: usize,
     pub z_i: Scalar,

--- a/src/common.rs
+++ b/src/common.rs
@@ -1,3 +1,4 @@
+use num_traits::Zero;
 use secp256k1_math::{
     point::{Point, G},
     scalar::Scalar,
@@ -7,7 +8,7 @@ use serde::{Deserialize, Serialize};
 use crate::compute::challenge;
 use crate::schnorr::ID;
 
-#[derive(Deserialize, Serialize)]
+#[derive(Clone, Deserialize, Serialize)]
 #[allow(non_snake_case)]
 pub struct PolyCommitment {
     pub id: ID,
@@ -20,13 +21,22 @@ impl PolyCommitment {
     }
 }
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 pub struct Nonce {
     pub d: Scalar,
     pub e: Scalar,
 }
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
+impl Nonce {
+    pub fn new() -> Self {
+        Self {
+            d: Scalar::zero(),
+            e: Scalar::zero(),
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 #[allow(non_snake_case)]
 pub struct PublicNonce {
     pub D: Point,
@@ -60,7 +70,7 @@ pub struct Signature {
 impl Signature {
     // verify: R' = z * G + -c * publicKey, pass if R' == R
     #[allow(non_snake_case)]
-    pub fn verify(&self, public_key: &Point, msg: &String) -> bool {
+    pub fn verify(&self, public_key: &Point, msg: &[u8]) -> bool {
         let c = challenge(&public_key, &self.R, &msg);
         let R = &self.z * G + (-c) * public_key;
 

--- a/src/common.rs
+++ b/src/common.rs
@@ -1,3 +1,4 @@
+use core::ops::Add;
 use num_traits::Zero;
 use secp256k1_math::{
     point::{Point, G},
@@ -27,11 +28,26 @@ pub struct Nonce {
     pub e: Scalar,
 }
 
-impl Default for Nonce {
-    fn default() -> Self {
+impl Zero for Nonce {
+    fn zero() -> Self {
         Self {
             d: Scalar::zero(),
             e: Scalar::zero(),
+        }
+    }
+
+    fn is_zero(&self) -> bool {
+        self.d == Scalar::zero() && self.e == Scalar::zero()
+    }
+}
+
+impl Add for Nonce {
+    type Output = Self;
+
+    fn add(self, other: Self) -> Self {
+        Self {
+            d: self.d + other.d,
+            e: self.e + other.e,
         }
     }
 }

--- a/src/common.rs
+++ b/src/common.rs
@@ -21,7 +21,7 @@ impl PolyCommitment {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
 pub struct Nonce {
     pub d: Scalar,
     pub e: Scalar,
@@ -36,7 +36,7 @@ impl Default for Nonce {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
 #[allow(non_snake_case)]
 pub struct PublicNonce {
     pub D: Point,

--- a/src/common.rs
+++ b/src/common.rs
@@ -27,8 +27,8 @@ pub struct Nonce {
     pub e: Scalar,
 }
 
-impl Nonce {
-    pub fn new() -> Self {
+impl Default for Nonce {
+    fn default() -> Self {
         Self {
             d: Scalar::zero(),
             e: Scalar::zero(),

--- a/src/common.rs
+++ b/src/common.rs
@@ -2,10 +2,12 @@ use secp256k1_math::{
     point::{Point, G},
     scalar::Scalar,
 };
+use serde::{Deserialize, Serialize};
 
 use crate::compute::challenge;
 use crate::schnorr::ID;
 
+#[derive(Deserialize, Serialize)]
 #[allow(non_snake_case)]
 pub struct PolyCommitment {
     pub id: ID,
@@ -18,13 +20,13 @@ impl PolyCommitment {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Nonce {
     pub d: Scalar,
     pub e: Scalar,
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 #[allow(non_snake_case)]
 pub struct PublicNonce {
     pub D: Point,
@@ -42,6 +44,7 @@ impl PublicNonce {
 
 // TODO: Remove public key from here
 // The SA should get that as usual
+#[derive(Deserialize, Serialize)]
 pub struct SignatureShare {
     pub id: usize,
     pub z_i: Scalar,

--- a/src/compute.rs
+++ b/src/compute.rs
@@ -45,16 +45,14 @@ pub fn lambda(i: &usize, indices: &[usize]) -> Scalar {
 
 // Is this the best way to return these values?
 #[allow(non_snake_case)]
-pub fn intermediate(
-    msg: &[u8],
-    signers: &[usize],
-    nonces: &[PublicNonce],
-) -> (Vec<Point>, Point) {
+pub fn intermediate(msg: &[u8], signers: &[usize], nonces: &[PublicNonce]) -> (Vec<Point>, Point) {
     let rhos: Vec<Scalar> = signers
         .iter()
         .map(|&i| binding(&Scalar::from((i + 1) as u32), nonces, &msg))
         .collect();
-    let R_vec: Vec<Point> = zip(nonces, rhos).map(|(nonce,rho)| nonce.D + rho * nonce.E).collect();
+    let R_vec: Vec<Point> = zip(nonces, rhos)
+        .map(|(nonce, rho)| nonce.D + rho * nonce.E)
+        .collect();
 
     let R = R_vec.iter().fold(Point::zero(), |R, &R_i| R + R_i);
     (R_vec, R)

--- a/src/compute.rs
+++ b/src/compute.rs
@@ -48,7 +48,7 @@ pub fn lambda(i: &usize, indices: &[usize]) -> Scalar {
 pub fn intermediate(msg: &[u8], signers: &[usize], nonces: &[PublicNonce]) -> (Vec<Point>, Point) {
     let rhos: Vec<Scalar> = signers
         .iter()
-        .map(|&i| binding(&Scalar::from((i + 1) as u32), nonces, &msg))
+        .map(|&i| binding(&Scalar::from((i + 1) as u32), nonces, msg))
         .collect();
     let R_vec: Vec<Point> = zip(nonces, rhos)
         .map(|(nonce, rho)| nonce.D + rho * nonce.E)

--- a/src/compute.rs
+++ b/src/compute.rs
@@ -1,3 +1,4 @@
+use core::iter::zip;
 use num_traits::{One, Zero};
 use secp256k1_math::{point::Point, scalar::Scalar};
 use sha3::{Digest, Sha3_256};
@@ -6,7 +7,7 @@ use crate::common::PublicNonce;
 use crate::util::hash_to_scalar;
 
 #[allow(non_snake_case)]
-pub fn binding(id: &Scalar, B: &Vec<PublicNonce>, msg: &String) -> Scalar {
+pub fn binding(id: &Scalar, B: &[PublicNonce], msg: &[u8]) -> Scalar {
     let mut hasher = Sha3_256::new();
 
     hasher.update(id.as_bytes());
@@ -14,23 +15,23 @@ pub fn binding(id: &Scalar, B: &Vec<PublicNonce>, msg: &String) -> Scalar {
         hasher.update(b.D.compress().as_bytes());
         hasher.update(b.E.compress().as_bytes());
     }
-    hasher.update(msg.as_bytes());
+    hasher.update(msg);
 
     hash_to_scalar(&mut hasher)
 }
 
 #[allow(non_snake_case)]
-pub fn challenge(publicKey: &Point, R: &Point, msg: &String) -> Scalar {
+pub fn challenge(publicKey: &Point, R: &Point, msg: &[u8]) -> Scalar {
     let mut hasher = Sha3_256::new();
 
     hasher.update(publicKey.compress().as_bytes());
     hasher.update(R.compress().as_bytes());
-    hasher.update(msg.as_bytes());
+    hasher.update(msg);
 
     hash_to_scalar(&mut hasher)
 }
 
-pub fn lambda(i: &usize, indices: &Vec<usize>) -> Scalar {
+pub fn lambda(i: &usize, indices: &[usize]) -> Scalar {
     let mut lambda = Scalar::one();
     let i_scalar = Scalar::from((i + 1) as u32);
     for j in indices {
@@ -45,17 +46,16 @@ pub fn lambda(i: &usize, indices: &Vec<usize>) -> Scalar {
 // Is this the best way to return these values?
 #[allow(non_snake_case)]
 pub fn intermediate(
-    signers: &Vec<usize>,
-    B: &Vec<Vec<PublicNonce>>,
-    index: usize,
-    msg: &String,
-) -> (Vec<PublicNonce>, Vec<Point>, Point) {
-    let B = signers.iter().map(|&i| B[i][index].clone()).collect();
-    let rho: Vec<Scalar> = signers
+    msg: &[u8],
+    signers: &[usize],
+    nonces: &[PublicNonce],
+) -> (Vec<Point>, Point) {
+    let rhos: Vec<Scalar> = signers
         .iter()
-        .map(|&i| binding(&Scalar::from((i + 1) as u32), &B, &msg))
+        .map(|&i| binding(&Scalar::from((i + 1) as u32), nonces, &msg))
         .collect();
-    let R_vec: Vec<Point> = (0..B.len()).map(|i| &B[i].D + &rho[i] * &B[i].E).collect();
+    let R_vec: Vec<Point> = zip(nonces, rhos).map(|(nonce,rho)| nonce.D + rho * nonce.E).collect();
+
     let R = R_vec.iter().fold(Point::zero(), |R, &R_i| R + R_i);
-    (B, R_vec, R)
+    (R_vec, R)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -106,13 +106,13 @@ fn main() {
             .map(|i| parties[*i].gen_nonce(&mut rng))
             .collect();
 
-        let mut sig_agg = SignatureAggregator::new(N, T, A.clone(), nonces.clone());
+        let mut sig_agg = SignatureAggregator::new(N, T, A.clone());
 
         let party_sig_start = time::Instant::now();
         let sig_shares = collect_signatures(&parties, &signers, &nonces, &msg);
         let party_sig_time = party_sig_start.elapsed();
         let sig_start = time::Instant::now();
-        let sig = sig_agg.sign(&msg, &sig_shares);
+        let sig = sig_agg.sign(&msg, &nonces, &sig_shares);
         let sig_time = sig_start.elapsed();
 
         total_party_sig_time += party_sig_time.as_micros();

--- a/src/main.rs
+++ b/src/main.rs
@@ -101,7 +101,7 @@ fn main() {
         let msg = "It was many and many a year ago".as_bytes();
         let signers = select_parties(N, T, &mut rng);
 
-        let nonces: Vec<PublicNonce> = parties.iter_mut().map(|p| p.gen_nonce(&mut rng)).collect();
+        let nonces: Vec<PublicNonce> = signers.iter().map(|i| parties[*i].gen_nonce(&mut rng)).collect();
 
         let mut sig_agg = SignatureAggregator::new(N, T, A.clone(), nonces.clone());
 
@@ -109,7 +109,7 @@ fn main() {
         let sig_shares = collect_signatures(&parties, &signers, &nonces, &msg);
         let party_sig_time = party_sig_start.elapsed();
         let sig_start = time::Instant::now();
-        let sig = sig_agg.sign(&msg, &signers, &sig_shares);
+        let sig = sig_agg.sign(&msg, &sig_shares);
         let sig_time = sig_start.elapsed();
 
         total_party_sig_time += party_sig_time.as_micros();

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,8 +11,7 @@ use hashbrown::HashMap;
 #[allow(non_snake_case)]
 fn distribute(
     parties: &mut Vec<Party>,
-    A: &Vec<PolyCommitment>,
-    B: &Vec<Vec<PublicNonce>>,
+    A: &[PolyCommitment],
 ) -> u128 {
     // each party broadcasts their commitments
     // these hashmaps will need to be serialized in tuples w/ the value encrypted
@@ -36,11 +35,6 @@ fn distribute(
         total_compute_secret_time += compute_secret_time.as_micros();
     }
 
-    // each party copies the nonces
-    for i in 0..parties.len() {
-        parties[i].set_group_nonces(B.clone());
-    }
-
     total_compute_secret_time
 }
 
@@ -62,44 +56,27 @@ fn select_parties<RNG: RngCore + CryptoRng>(N: usize, T: usize, rng: &mut RNG) -
 
 // There might be a slick one-liner for this?
 fn collect_signatures(
-    parties: &Vec<Party>,
-    signers: &Vec<usize>,
-    nonce_ctr: usize,
-    msg: &String,
+    parties: &[Party],
+    signers: &[usize],
+    nonces: &[PublicNonce],
+    msg: &[u8]
 ) -> Vec<SignatureShare> {
     let mut sigs = Vec::new();
     for i in 0..signers.len() {
         let party = &parties[signers[i]];
         sigs.push(SignatureShare {
             id: party.id.clone(),
-            z_i: party.sign(&msg, &signers, nonce_ctr),
+            z_i: party.sign(&msg, &signers, nonces),
             public_key: party.public_key.clone(),
         });
     }
     sigs
 }
 
-// In case one party loses their nonces & needs to regenerate
-#[allow(non_snake_case)]
-fn reset_nonce<RNG: RngCore + CryptoRng>(
-    parties: &mut Vec<Party>,
-    sa: &mut SignatureAggregator,
-    i: usize,
-    num_nonces: u32,
-    rng: &mut RNG,
-) {
-    let B = &parties[i].gen_nonces(num_nonces, rng);
-    for p in parties {
-        p.set_party_nonces(i, B.clone());
-    }
-    sa.set_party_nonces(i, B.clone());
-}
-
 #[allow(non_snake_case)]
 fn main() {
     let args: Vec<String> = env::args().collect();
     let num_sigs = 7;
-    let num_nonces = 5;
     let N: usize = if args.len() > 1 {
         args[1].parse::<usize>().unwrap()
     } else {
@@ -119,25 +96,26 @@ fn main() {
         .iter()
         .map(|p| p.get_poly_commitment(&mut rng))
         .collect();
-    let B: Vec<Vec<PublicNonce>> = parties
-        .iter_mut()
-        .map(|p| p.gen_nonces(num_nonces, &mut rng))
-        .collect();
-    let total_compute_secret_time = distribute(&mut parties, &A, &B);
-
-    let mut sig_agg = SignatureAggregator::new(N, T, A, B);
+    let total_compute_secret_time = distribute(&mut parties, &A);
 
     let mut total_sig_time = 0;
     let mut total_party_sig_time = 0;
-    for sig_ct in 0..num_sigs {
-        let msg = "It was many and many a year ago".to_string();
+    for _ in 0..num_sigs {
+        let msg = "It was many and many a year ago".as_bytes();
         let signers = select_parties(N, T, &mut rng);
-        let nonce_ctr = sig_agg.get_nonce_ctr();
+
+        let nonces: Vec<PublicNonce> = parties
+            .iter_mut()
+            .map(|p| p.gen_nonce(&mut rng))
+            .collect();
+
+        let mut sig_agg = SignatureAggregator::new(N, T, A.clone(), nonces.clone());
+        
         let party_sig_start = time::Instant::now();
-        let sig_shares = collect_signatures(&parties, &signers, nonce_ctr, &msg);
+        let sig_shares = collect_signatures(&parties, &signers, &nonces, &msg);
         let party_sig_time = party_sig_start.elapsed();
         let sig_start = time::Instant::now();
-        let sig = sig_agg.sign(&msg, &sig_shares, &signers);
+        let sig = sig_agg.sign(&msg, &signers, &sig_shares);
         let sig_time = sig_start.elapsed();
 
         total_party_sig_time += party_sig_time.as_micros();
@@ -145,31 +123,6 @@ fn main() {
 
         println!("Signature (R,z) = \n({},{})", sig.R, sig.z);
         assert!(sig.verify(&sig_agg.key, &msg));
-
-        // this resets one party's nonces assuming it went down and needed to regenerate
-        if sig_ct == 3 {
-            let reset_party = 2;
-            println!("Resetting nonce for party {}", reset_party);
-            reset_nonce(
-                &mut parties,
-                &mut sig_agg,
-                reset_party,
-                num_nonces,
-                &mut rng,
-            );
-        }
-
-        if sig_agg.get_nonce_ctr() == num_nonces as usize {
-            println!("Everyone's nonces were refilled.");
-            let B: Vec<Vec<PublicNonce>> = parties
-                .iter_mut()
-                .map(|p| p.gen_nonces(num_nonces, &mut rng))
-                .collect();
-            for p in &mut parties {
-                p.set_group_nonces(B.clone());
-            }
-            sig_agg.set_group_nonces(B.clone());
-        }
     }
     println!("With {} parties and {} signers:", N, T);
     println!(

--- a/src/main.rs
+++ b/src/main.rs
@@ -101,7 +101,10 @@ fn main() {
         let msg = "It was many and many a year ago".as_bytes();
         let signers = select_parties(N, T, &mut rng);
 
-        let nonces: Vec<PublicNonce> = signers.iter().map(|i| parties[*i].gen_nonce(&mut rng)).collect();
+        let nonces: Vec<PublicNonce> = signers
+            .iter()
+            .map(|i| parties[*i].gen_nonce(&mut rng))
+            .collect();
 
         let mut sig_agg = SignatureAggregator::new(N, T, A.clone(), nonces.clone());
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,10 +9,7 @@ use hashbrown::HashMap;
 
 // This will eventually need to be replaced by rpcs
 #[allow(non_snake_case)]
-fn distribute(
-    parties: &mut Vec<Party>,
-    A: &[PolyCommitment],
-) -> u128 {
+fn distribute(parties: &mut Vec<Party>, A: &[PolyCommitment]) -> u128 {
     // each party broadcasts their commitments
     // these hashmaps will need to be serialized in tuples w/ the value encrypted
     let mut broadcast_shares = Vec::new();
@@ -59,7 +56,7 @@ fn collect_signatures(
     parties: &[Party],
     signers: &[usize],
     nonces: &[PublicNonce],
-    msg: &[u8]
+    msg: &[u8],
 ) -> Vec<SignatureShare> {
     let mut sigs = Vec::new();
     for i in 0..signers.len() {
@@ -104,13 +101,10 @@ fn main() {
         let msg = "It was many and many a year ago".as_bytes();
         let signers = select_parties(N, T, &mut rng);
 
-        let nonces: Vec<PublicNonce> = parties
-            .iter_mut()
-            .map(|p| p.gen_nonce(&mut rng))
-            .collect();
+        let nonces: Vec<PublicNonce> = parties.iter_mut().map(|p| p.gen_nonce(&mut rng)).collect();
 
         let mut sig_agg = SignatureAggregator::new(N, T, A.clone(), nonces.clone());
-        
+
         let party_sig_start = time::Instant::now();
         let sig_shares = collect_signatures(&parties, &signers, &nonces, &msg);
         let party_sig_time = party_sig_start.elapsed();

--- a/src/schnorr.rs
+++ b/src/schnorr.rs
@@ -3,12 +3,13 @@ use secp256k1_math::{
     point::{Point, G},
     scalar::Scalar,
 };
+use serde::{Deserialize, Serialize};
 use sha3::{Digest, Sha3_256};
 
 use crate::util::hash_to_scalar;
 
 #[allow(non_snake_case)]
-#[derive(Clone)]
+#[derive(Clone, Deserialize, Serialize)]
 pub struct ID {
     pub id: Scalar,
     pub kG: Point,

--- a/src/schnorr.rs
+++ b/src/schnorr.rs
@@ -23,7 +23,7 @@ impl ID {
         let c = Self::challenge(id, &(&k * &G), &(a * &G));
 
         Self {
-            id: id.clone(),
+            id: *id,
             kG: &k * G,
             kca: &k + c * a,
         }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -3,8 +3,6 @@ use rand_core::{CryptoRng, RngCore};
 use crate::common::{PublicNonce, SignatureShare};
 
 pub trait Signer {
-    fn new<RNG: RngCore + CryptoRng>(ids: &[usize], n: usize, t: usize, rng: &mut RNG) -> Self;
-
     fn gen_nonces<RNG: RngCore + CryptoRng>(&mut self, rng: &mut RNG) -> Vec<PublicNonce>;
 
     fn sign(&self, msg: &[u8], signers: &[usize], nonces: &[PublicNonce]) -> Vec<SignatureShare>;

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -6,6 +6,6 @@ pub trait Signer {
     fn new<RNG: RngCore + CryptoRng>(ids: &[usize], n: usize, t: usize, rng: &mut RNG) -> Self;
 
     fn gen_nonces<RNG: RngCore + CryptoRng>(&mut self, rng: &mut RNG) -> Vec<(usize, PublicNonce)>;
-    
+
     fn sign(&self, msg: &[u8], signers: &[usize], nonces: &[PublicNonce]) -> Vec<SignatureShare>;
 }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1,6 +1,8 @@
+use rand_core::{CryptoRng, RngCore};
+
 pub trait Signer {
-    fn new(num_keys: usize) -> Self;
+    fn new<RNG: RngCore + CryptoRng>(ids: &[usize], n: usize, t: usize, rng: &mut RNG) -> Self;
     fn load(path: &str) -> Self;
 
-    fn save(path: &str);
+    fn save(&self, path: &str);
 }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1,8 +1,11 @@
 use rand_core::{CryptoRng, RngCore};
 
+use crate::common::{PublicNonce, SignatureShare};
+
 pub trait Signer {
     fn new<RNG: RngCore + CryptoRng>(ids: &[usize], n: usize, t: usize, rng: &mut RNG) -> Self;
-    fn load(path: &str) -> Self;
 
-    fn save(&self, path: &str);
+    fn gen_nonces<RNG: RngCore + CryptoRng>(&mut self, rng: &mut RNG) -> Vec<(usize, PublicNonce)>;
+    
+    fn sign(&self, msg: &[u8], signers: &[usize], nonces: &[PublicNonce]) -> Vec<SignatureShare>;
 }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -5,7 +5,7 @@ use crate::common::{PublicNonce, SignatureShare};
 pub trait Signer {
     fn new<RNG: RngCore + CryptoRng>(ids: &[usize], n: usize, t: usize, rng: &mut RNG) -> Self;
 
-    fn gen_nonces<RNG: RngCore + CryptoRng>(&mut self, rng: &mut RNG) -> Vec<(usize, PublicNonce)>;
+    fn gen_nonces<RNG: RngCore + CryptoRng>(&mut self, rng: &mut RNG) -> Vec<PublicNonce>;
 
     fn sign(&self, msg: &[u8], signers: &[usize], nonces: &[PublicNonce]) -> Vec<SignatureShare>;
 }

--- a/src/v1.rs
+++ b/src/v1.rs
@@ -21,7 +21,6 @@ pub struct Party {
     pub public_key: Point,
     n: usize,
     f: Polynomial<Scalar>,
-    //shares: HashMap<usize, Scalar>, // received from other parties
     private_key: Scalar,
     group_key: Point,
     nonce: Nonce,

--- a/src/v1.rs
+++ b/src/v1.rs
@@ -63,7 +63,7 @@ impl Party {
 
     pub fn get_shares(&self) -> HashMap<usize, Scalar> {
         let mut shares = HashMap::new();
-        for i in 0..self.n as usize {
+        for i in 0..self.n {
             shares.insert(i, self.f.eval(Scalar::from((i + 1) as u32)));
         }
         shares
@@ -85,7 +85,7 @@ impl Party {
                         + (Scalar::from((self.id + 1) as u32) ^ j) * Ai.A[j])
             );
             self.private_key += s;
-            self.group_key += Ai.A[0].clone();
+            self.group_key += Ai.A[0];
         }
         self.public_key = self.private_key * G;
         println!("Party {} secret {}", self.id, self.private_key);
@@ -97,7 +97,7 @@ impl Party {
 
     #[allow(non_snake_case)]
     pub fn sign(&self, msg: &[u8], signers: &[usize], nonces: &[PublicNonce]) -> Scalar {
-        let (_R_vec, R) = compute::intermediate(msg, &signers, nonces);
+        let (_R_vec, R) = compute::intermediate(msg, signers, nonces);
         let mut z = &self.nonce.d + &self.nonce.e * compute::binding(&self.id(), nonces, msg);
         z += compute::challenge(&self.group_key, &R, msg)
             * &self.private_key
@@ -141,7 +141,7 @@ impl SignatureAggregator {
         let signers: Vec<usize> = sig_shares.iter().map(|ss| ss.id).collect();
         let (R_vec, R) = compute::intermediate(msg, &signers, &self.B);
         let mut z = Scalar::zero();
-        let c = compute::challenge(&self.key, &R, &msg); // only needed for checking z_i
+        let c = compute::challenge(&self.key, &R, msg); // only needed for checking z_i
 
         for i in 0..sig_shares.len() {
             let z_i = sig_shares[i].z_i;

--- a/src/v1.rs
+++ b/src/v1.rs
@@ -317,7 +317,7 @@ mod tests {
 
         assert_eq!(signer, loaded);
     }
-
+/*
     #[allow(non_snake_case)]
     fn dkg<RNG: RngCore + CryptoRng>(signers: &mut Vec<v1::Signer>, rng: &mut RNG) -> Vec<PolyCommitment> {
         let A: Vec<PolyCommitment> = signers
@@ -367,8 +367,8 @@ mod tests {
         let msg = "It was many and many a year ago".as_bytes();
         let N: usize = 10;
         let T: usize = 7;
-        let signer_ids: Vec<Vec<usize>> = [[0, 1, 2],to_vec(), [3, 4].to_vec(), [5, 6, 7].to_vec(), [8, 9].to_vec()].to_vec();
-        let signers = ids.iter().map(|ids| v1::Signer::new(ids, N, T, &mut rng)).collect();
+        let signer_ids: Vec<Vec<usize>> = [[0, 1, 2].to_vec(), [3, 4].to_vec(), [5, 6, 7].to_vec(), [8, 9].to_vec()].to_vec();
+        let signers = signer_ids.iter().map(|ids| v1::Signer::new(ids, N, T, &mut rng)).collect();
 
         let A = dkg(&mut signers, &mut rng);
         
@@ -384,4 +384,5 @@ mod tests {
             assert!(sig.verify(&sig_agg.key, &msg));
         }
     }
+    */
 }

--- a/src/v1.rs
+++ b/src/v1.rs
@@ -199,6 +199,15 @@ pub struct Signer {
 }
 
 impl Signer {
+    pub fn new<RNG: RngCore + CryptoRng>(ids: &[usize], n: usize, t: usize, rng: &mut RNG) -> Self {
+        let parties = ids.iter().map(|id| Party::new(*id, n, t, rng)).collect();
+        Signer {
+            n,
+            group_key: Point::zero(),
+            parties,
+        }
+    }
+
     pub fn load(state: &SignerState) -> Self {
         let parties = state
             .parties
@@ -243,15 +252,6 @@ impl Signer {
 }
 
 impl crate::traits::Signer for Signer {
-    fn new<RNG: RngCore + CryptoRng>(ids: &[usize], n: usize, t: usize, rng: &mut RNG) -> Self {
-        let parties = ids.iter().map(|id| Party::new(*id, n, t, rng)).collect();
-        Signer {
-            n,
-            group_key: Point::zero(),
-            parties,
-        }
-    }
-
     fn gen_nonces<RNG: RngCore + CryptoRng>(&mut self, rng: &mut RNG) -> Vec<PublicNonce> {
         self.parties.iter_mut().map(|p| p.gen_nonce(rng)).collect()
     }

--- a/src/v1.rs
+++ b/src/v1.rs
@@ -42,7 +42,7 @@ impl Party {
             private_key: Scalar::zero(),
             public_key: Point::zero(),
             group_key: Point::zero(),
-            nonce: Nonce::default(),
+            nonce: Nonce::zero(),
         }
     }
 
@@ -54,7 +54,7 @@ impl Party {
             private_key: state.private_key,
             public_key: &state.private_key * G,
             group_key: *group_key,
-            nonce: Nonce::default(),
+            nonce: Nonce::zero(),
         }
     }
 
@@ -270,11 +270,12 @@ impl crate::traits::Signer for Signer {
 
 #[cfg(test)]
 mod tests {
-    use crate::common::{Nonce, PolyCommitment, PublicNonce, SignatureShare};
+    use crate::common::{PolyCommitment, PublicNonce, SignatureShare};
     use crate::traits::Signer;
     use crate::v1;
 
     use hashbrown::HashMap;
+    use num_traits::Zero;
     use rand_core::{CryptoRng, OsRng, RngCore};
 
     #[test]
@@ -299,7 +300,7 @@ mod tests {
         let mut signer = v1::Signer::new(&ids, n, t, &mut rng);
 
         for party in &signer.parties {
-            assert!(party.nonce == Nonce::default());
+            assert!(party.nonce.is_zero());
         }
 
         let nonces = signer.gen_nonces(&mut rng);
@@ -307,7 +308,7 @@ mod tests {
         assert_eq!(nonces.len(), ids.len());
 
         for party in &signer.parties {
-            assert!(party.nonce != Nonce::default());
+            assert!(!party.nonce.is_zero());
         }
     }
 

--- a/src/v1.rs
+++ b/src/v1.rs
@@ -20,7 +20,6 @@ pub struct Party {
     pub id: usize,
     pub public_key: Point,
     n: usize,
-    _t: usize,
     f: Polynomial<Scalar>,
     //shares: HashMap<usize, Scalar>, // received from other parties
     private_key: Scalar,
@@ -34,7 +33,6 @@ impl Party {
         Self {
             id: id,
             n: n,
-            _t: t,
             f: VSS::random_poly(t - 1, rng),
             private_key: Scalar::zero(),
             public_key: Point::zero(),

--- a/src/v1.rs
+++ b/src/v1.rs
@@ -20,7 +20,7 @@ pub struct PartyState {
     pub polynomial: Polynomial<Scalar>,
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 #[allow(non_snake_case)]
 pub struct Party {
     pub id: usize,
@@ -191,7 +191,7 @@ pub struct SignerState {
     parties: HashMap<usize, PartyState>,
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Signer {
     pub n: usize,
     pub group_key: Point,

--- a/src/v1.rs
+++ b/src/v1.rs
@@ -143,11 +143,7 @@ impl SignatureAggregator {
     }
 
     #[allow(non_snake_case)]
-    pub fn sign(
-        &mut self,
-        msg: &[u8],
-        sig_shares: &[SignatureShare],
-    ) -> Signature {
+    pub fn sign(&mut self, msg: &[u8], sig_shares: &[SignatureShare]) -> Signature {
         let signers: Vec<usize> = sig_shares.iter().map(|ss| ss.id).collect();
         let (R_vec, R) = compute::intermediate(msg, &signers, &self.B);
         let mut z = Scalar::zero();

--- a/src/v1.rs
+++ b/src/v1.rs
@@ -60,7 +60,7 @@ impl Party {
 
     pub fn save(&self) -> PartyState {
         PartyState {
-            private_key: self.private_key.clone(),
+            private_key: self.private_key,
             polynomial: self.f.clone(),
         }
     }
@@ -164,7 +164,7 @@ impl SignatureAggregator {
         sig_shares: &[SignatureShare],
     ) -> Signature {
         let signers: Vec<usize> = sig_shares.iter().map(|ss| ss.id).collect();
-        let (R_vec, R) = compute::intermediate(msg, &signers, &nonces);
+        let (R_vec, R) = compute::intermediate(msg, &signers, nonces);
         let mut z = Scalar::zero();
         let c = compute::challenge(&self.key, &R, msg); // only needed for checking z_i
 
@@ -203,7 +203,7 @@ impl Signer {
         let parties = state
             .parties
             .iter()
-            .map(|(id, ps)| Party::load(*id, state.n, &state.group_key, &ps))
+            .map(|(id, ps)| Party::load(*id, state.n, &state.group_key, ps))
             .collect();
 
         Self {

--- a/src/v1.rs
+++ b/src/v1.rs
@@ -66,12 +66,7 @@ impl Party {
     }
 
     pub fn gen_nonce<RNG: RngCore + CryptoRng>(&mut self, rng: &mut RNG) -> PublicNonce {
-        let nonce = Nonce {
-            d: Scalar::random(rng),
-            e: Scalar::random(rng),
-        };
-
-        self.nonce = nonce;
+        self.nonce = Nonce::random(rng);
 
         PublicNonce::from(&self.nonce)
     }


### PR DESCRIPTION
This branch adds a ```Signer``` trait and a ```v1::Signer``` object.  A signer wraps one or more parties in a convenient interface, to save applications from the hassle of juggling multiple parties.  Unit tests have been added to test ```v1::Signer```'s ```Signer``` trait ```fn```s.

It also adds a minimal state object to help persisting and restoring ```v1::Signer``` objects, and makes a number of changes to the way we handle nonces in v1.  We now gather nonces only from the signing set, and only use those nonces when computing binding values and signing.  A lot of opaque indexing and redundant data was removed.

There are also a number of clippy fixes.  Several clippy flags have been disabled where they were not useful.