### PR TITLE
Reorg v2 to use common crate and ephemeral nonces

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 *~
+Cargo.lock

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ hex = "0.4.3"
 num-traits = "0.2"
 polynomial = { git = "https://github.com/Trust-Machines/polynomial-rs", rev = "3e2fafa6e85dec5b84006374ffe1cc83473182e5", features = ["serde"] }
 rand_core = "0.5"
-secp256k1-math = { git = "https://github.com/Trust-Machines/rust-secp256k1-math", rev = "ad35f79ce18d67fdd3c11697066b28ea38c5fbde" }
+secp256k1-math = { git = "https://github.com/Trust-Machines/rust-secp256k1-math", rev = "5234bd790aea89104e7b0bfc4912b05b89940323" }
 serde = { version = "1.0", features = ["derive"] }
 sha3 = "0.10.5"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ hex = "0.4.3"
 num-traits = "0.2"
 polynomial = { git = "https://github.com/Trust-Machines/polynomial-rs", rev = "3e2fafa6e85dec5b84006374ffe1cc83473182e5", features = ["serde"] }
 rand_core = "0.5"
-secp256k1-math = { git = "https://github.com/Trust-Machines/rust-secp256k1-math", rev = "5234bd790aea89104e7b0bfc4912b05b89940323" }
+secp256k1-math = { git = "https://github.com/Trust-Machines/rust-secp256k1-math", rev = "f1720d822a0903bb84d6e86dcf2c71ba4e67a0bc" }
 serde = { version = "1.0", features = ["derive"] }
 sha3 = "0.10.5"
 

--- a/src/common.rs
+++ b/src/common.rs
@@ -100,7 +100,8 @@ impl Signature {
         let c = challenge(public_key, &self.R, msg);
         let R = &self.z * G + (-c) * public_key;
 
-        println!("Verification R = {}", R);
+        println!("Signature R    {}", self.R);
+        println!("Verification R {}", R);
 
         R == self.R
     }

--- a/src/common.rs
+++ b/src/common.rs
@@ -100,9 +100,6 @@ impl Signature {
         let c = challenge(public_key, &self.R, msg);
         let R = &self.z * G + (-c) * public_key;
 
-        println!("Signature R    {}", self.R);
-        println!("Verification R {}", R);
-
         R == self.R
     }
 }

--- a/src/compute.rs
+++ b/src/compute.rs
@@ -31,12 +31,12 @@ pub fn challenge(publicKey: &Point, R: &Point, msg: &[u8]) -> Scalar {
     hash_to_scalar(&mut hasher)
 }
 
-pub fn lambda(i: &usize, indices: &[usize]) -> Scalar {
+pub fn lambda(i: usize, indices: &[usize]) -> Scalar {
     let mut lambda = Scalar::one();
-    let i_scalar = Scalar::from((i + 1) as u32);
+    let i_scalar = id(i);
     for j in indices {
-        if i != j {
-            let j_scalar = Scalar::from((j + 1) as u32);
+        if i != *j {
+            let j_scalar = id(*j);
             lambda *= j_scalar / (j_scalar - i_scalar);
         }
     }
@@ -48,7 +48,7 @@ pub fn lambda(i: &usize, indices: &[usize]) -> Scalar {
 pub fn intermediate(msg: &[u8], signers: &[usize], nonces: &[PublicNonce]) -> (Vec<Point>, Point) {
     let rhos: Vec<Scalar> = signers
         .iter()
-        .map(|&i| binding(&Scalar::from((i + 1) as u32), nonces, msg))
+        .map(|&i| binding(&id(i), nonces, msg))
         .collect();
     let R_vec: Vec<Point> = zip(nonces, rhos)
         .map(|(nonce, rho)| nonce.D + rho * nonce.E)

--- a/src/compute.rs
+++ b/src/compute.rs
@@ -57,3 +57,7 @@ pub fn intermediate(msg: &[u8], signers: &[usize], nonces: &[PublicNonce]) -> (V
     let R = R_vec.iter().fold(Point::zero(), |R, &R_i| R + R_i);
     (R_vec, R)
 }
+
+pub fn id(i: usize) -> Scalar {
+    Scalar::from((i + 1) as u32)
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,3 @@ pub mod util;
 pub mod v1;
 pub mod v2;
 pub mod vss;
-
-#[cfg(test)]
-mod test_v2;

--- a/src/main.rs
+++ b/src/main.rs
@@ -61,11 +61,7 @@ fn collect_signatures(
     let mut sigs = Vec::new();
     for i in 0..signers.len() {
         let party = &parties[signers[i]];
-        sigs.push(SignatureShare {
-            id: party.id,
-            z_i: party.sign(msg, signers, nonces),
-            public_key: party.public_key,
-        });
+        sigs.push(party.sign(msg, signers, nonces));
     }
     sigs
 }

--- a/src/v1.rs
+++ b/src/v1.rs
@@ -112,7 +112,7 @@ impl Party {
     }
 
     fn id(&self) -> Scalar {
-        Scalar::from((self.id + 1) as u32)
+        compute::id(self.id)
     }
 
     #[allow(non_snake_case)]
@@ -121,7 +121,7 @@ impl Party {
         let mut z = &self.nonce.d + &self.nonce.e * compute::binding(&self.id(), nonces, msg);
         z += compute::challenge(&self.group_key, &R, msg)
             * &self.private_key
-            * compute::lambda(&self.id, signers);
+            * compute::lambda(self.id, signers);
         z
     }
 }
@@ -168,7 +168,7 @@ impl SignatureAggregator {
             assert!(
                 z_i * G
                     == R_vec[i]
-                        + (compute::lambda(&sig_shares[i].id, &signers)
+                        + (compute::lambda(sig_shares[i].id, &signers)
                             * c
                             * sig_shares[i].public_key)
             ); // TODO: This should return a list of bad parties.
@@ -376,7 +376,7 @@ mod tests {
 
     #[allow(non_snake_case)]
     #[test]
-    fn signer_sign() {
+    fn aggregator_sign() {
         let mut rng = OsRng::default();
         let msg = "It was many and many a year ago".as_bytes();
         let N: usize = 10;

--- a/src/v1.rs
+++ b/src/v1.rs
@@ -108,7 +108,6 @@ impl Party {
             self.group_key += Ai.A[0];
         }
         self.public_key = self.private_key * G;
-        println!("Party {} secret {}", self.id, self.private_key);
     }
 
     fn id(&self) -> Scalar {
@@ -151,7 +150,7 @@ impl SignatureAggregator {
         for A_i in &A {
             key += &A_i.A[0];
         }
-        println!("SA groupKey {}", key);
+        //println!("SA groupKey {}", key);
 
         Self { N, T, key }
     }
@@ -406,7 +405,7 @@ mod tests {
             let (nonces, sig_shares) = sign(&msg, &mut signers, &mut rng);
             let sig = sig_agg.sign(&msg, &nonces, &sig_shares);
 
-            println!("Signature (R,z) = \n({},{})", sig.R, sig.z);
+            //println!("Signature (R,z) = \n({},{})", sig.R, sig.z);
             assert!(sig.verify(&sig_agg.key, &msg));
         }
     }

--- a/src/v1.rs
+++ b/src/v1.rs
@@ -161,7 +161,7 @@ impl SignatureAggregator {
         let signers: Vec<usize> = sig_shares.iter().map(|ss| ss.id).collect();
         let (R_vec, R) = compute::intermediate(msg, &signers, nonces);
         let mut z = Scalar::zero();
-        let c = compute::challenge(&self.key, &R, msg); // only needed for checking z_i
+        let c = compute::challenge(&self.key, &R, msg);
 
         for i in 0..sig_shares.len() {
             let z_i = sig_shares[i].z_i;
@@ -171,7 +171,7 @@ impl SignatureAggregator {
                         + (compute::lambda(sig_shares[i].id, &signers)
                             * c
                             * sig_shares[i].public_key)
-            ); // TODO: This should return a list of bad parties.
+            ); // TODO: This should return a list of bad parties
             z += z_i;
         }
 

--- a/src/v2.rs
+++ b/src/v2.rs
@@ -120,10 +120,6 @@ impl Party {
             }
             self.public_keys
                 .insert(*key_id, self.private_keys[key_id] * G);
-            println!(
-                "Party {} key_id {} secret {}",
-                self.party_id, key_id, self.private_keys[key_id]
-            );
         }
 
         &self.public_keys
@@ -143,7 +139,6 @@ impl Party {
     ) -> SignatureShare {
         //println!("signers: {:?}\nnonces: {:?}", signers, nonces);
         let (_R_vec, R) = compute::intermediate(msg, party_ids, nonces);
-        println!("party sign R {}", &R);
         let c = compute::challenge(&self.group_key, &R, msg);
 
         let mut z = &self.nonce.d + &self.nonce.e * compute::binding(&self.id(), nonces, msg);
@@ -181,7 +176,7 @@ impl SignatureAggregator {
         for A_i in &A {
             group_key += &A_i.A[0];
         }
-        println!("SA groupKey {}", group_key);
+        //println!("SA groupKey {}", group_key);
 
         Self {
             num_keys,
@@ -202,7 +197,6 @@ impl SignatureAggregator {
 
         let party_ids: Vec<usize> = sig_shares.iter().map(|ss| ss.party_id).collect();
         let (Ris, R) = compute::intermediate(msg, &party_ids, nonces);
-        println!("aggre sign R {}", &R);
         let mut z = Scalar::zero();
         let c = compute::challenge(&self.group_key, &R, msg);
 
@@ -319,7 +313,7 @@ mod tests {
             let (nonces, sig_shares, key_ids) = sign(&msg, &mut signers, &mut rng);
             let sig = sig_agg.sign(&msg, &nonces, &sig_shares, &key_ids);
 
-            println!("Signature (R,z) = \n({},{})", sig.R, sig.z);
+            //println!("Signature (R,z) = \n({},{})", sig.R, sig.z);
             assert!(sig.verify(&sig_agg.group_key, &msg));
         }
     }

--- a/src/v2.rs
+++ b/src/v2.rs
@@ -82,7 +82,7 @@ impl Party {
 
     pub fn get_shares(&self) -> HashMap<usize, Scalar> {
         let mut shares = HashMap::new();
-        for i in self.num_keys {
+        for i in 0..self.num_keys {
             shares.insert(i, self.f.eval(compute::id(i)));
         }
         shares
@@ -223,7 +223,6 @@ impl SignatureAggregator {
 #[cfg(test)]
 mod tests {
     use crate::common::{PolyCommitment, PublicNonce};
-    use crate::traits::Signer;
     use crate::v2;
     use crate::v2::SignatureShare;
 

--- a/src/v2.rs
+++ b/src/v2.rs
@@ -64,10 +64,7 @@ impl Party {
         }
     }
 
-    pub fn gen_nonce<RNG: RngCore + CryptoRng>(
-        &mut self,
-        rng: &mut RNG,
-    ) -> PublicNonce {
+    pub fn gen_nonce<RNG: RngCore + CryptoRng>(&mut self, rng: &mut RNG) -> PublicNonce {
         self.nonce = Nonce::random(rng);
 
         PublicNonce::from(&self.nonce)
@@ -136,7 +133,6 @@ impl Party {
         compute::id(self.party_id)
     }
 
-
     #[allow(non_snake_case)]
     // signers are party_ids, not key_ids
     pub fn sign(&self, msg: &[u8], signers: &[usize], nonces: &[PublicNonce]) -> SignatureShare {
@@ -160,7 +156,7 @@ impl Party {
 pub struct SignatureAggregator {
     pub num_keys: usize,
     pub threshold: usize,
-    pub group_key: Point,       // the group's combined public key
+    pub group_key: Point, // the group's combined public key
 }
 
 impl SignatureAggregator {
@@ -169,7 +165,7 @@ impl SignatureAggregator {
         num_keys: usize,
         num_parties: usize,
         threshold: usize,
-        A: Vec<PolyCommitment>, // one per party_id
+        A: Vec<PolyCommitment>,  // one per party_id
         _public_keys: PubKeyMap, // one per key_id
     ) -> Self {
         assert!(A.len() == num_parties);
@@ -207,11 +203,13 @@ impl SignatureAggregator {
             assert!(
                 z_i * G
                     == Ris[i]
-                    + sig_shares
-                        .iter()
-                        .enumerate()
-                        .fold(Point::zero(), |p, (k,share)| p + compute::lambda(share.party_id, &signers)
-                                * c
+                        + sig_shares
+                            .iter()
+                            .enumerate()
+                            .fold(Point::zero(), |p, (k, share)| p + compute::lambda(
+                                share.party_id,
+                                &signers
+                            ) * c
                                 * share.public_keys[&k])
             );
             z += z_i;
@@ -227,8 +225,8 @@ impl SignatureAggregator {
 mod tests {
     use crate::common::{PolyCommitment, PublicNonce};
     use crate::traits::Signer;
-    use crate::v2::SignatureShare;
     use crate::v2;
+    use crate::v2::SignatureShare;
 
     use hashbrown::HashMap;
     use rand_core::{CryptoRng, OsRng, RngCore};
@@ -238,10 +236,7 @@ mod tests {
         signers: &mut Vec<v2::Party>,
         rng: &mut RNG,
     ) -> Vec<PolyCommitment> {
-        let A: Vec<PolyCommitment> = signers
-            .iter()
-            .map(|s| s.get_poly_commitment(rng))
-            .collect();
+        let A: Vec<PolyCommitment> = signers.iter().map(|s| s.get_poly_commitment(rng)).collect();
 
         // each party broadcasts their commitments
         // these hashmaps will need to be serialized in tuples w/ the value encrypted
@@ -302,7 +297,8 @@ mod tests {
         ]
         .to_vec();
         let mut signers = party_key_ids
-            .iter().enumerate()
+            .iter()
+            .enumerate()
             .map(|(pid, pkids)| v2::Party::new(pid, pkids, party_key_ids.len(), N, T, &mut rng))
             .collect();
 

--- a/src/v2.rs
+++ b/src/v2.rs
@@ -5,8 +5,9 @@ use secp256k1_math::{
     point::{Point, G},
     scalar::Scalar,
 };
+use serde::{Deserialize, Serialize};
 
-use crate::common::{Nonce, PolyCommitment, PublicNonce, Signature, SignatureShare};
+use crate::common::{Nonce, PolyCommitment, PublicNonce, Signature};
 use crate::compute;
 use crate::schnorr::ID;
 use crate::vss::VSS;
@@ -16,6 +17,15 @@ use hashbrown::{HashMap, HashSet};
 pub type PubKeyMap = HashMap<usize, Point>;
 pub type PrivKeyMap = HashMap<usize, Scalar>;
 pub type SelectedSigners = HashMap<usize, HashSet<usize>>;
+
+// TODO: Remove public key from here
+// The SA should get that as usual
+#[derive(Debug, Deserialize, Serialize)]
+pub struct SignatureShare {
+    pub party_id: usize,
+    pub z_i: Scalar,
+    pub public_keys: HashMap<usize, Point>,
+}
 
 #[derive(Clone)]
 #[allow(non_snake_case)]
@@ -36,8 +46,8 @@ impl Party {
     pub fn new<RNG: RngCore + CryptoRng>(
         party_id: usize,
         key_ids: HashSet<usize>,
-        num_keys: usize,
         num_parties: usize,
+        num_keys: usize,
         threshold: usize,
         rng: &mut RNG,
     ) -> Self {
@@ -128,29 +138,29 @@ impl Party {
 
 
     #[allow(non_snake_case)]
-    pub fn sign(&self, msg: &[u8], signers: &[usize], nonces: &[PublicNonce]) -> Scalar {
+    // signers are party_ids, not key_ids
+    pub fn sign(&self, msg: &[u8], signers: &[usize], nonces: &[PublicNonce]) -> SignatureShare {
         let (_R_vec, R) = compute::intermediate(msg, signers, nonces);
         let c = compute::challenge(&self.group_key, &R, &msg);
 
-        let mut z = &nonce.d + &nonce.e * compute_binding(&id_to_scalar(&self.party_id), &B, &msg);
-        for key_id in signers[&self.party_id].iter() {
-            z += c * &self.private_keys[key_id] * lambda(&key_id, signers);
+        let mut z = &self.nonce.d + &self.nonce.e * compute::binding(&self.id(), nonces, msg);
+        for key_id in self.key_ids.iter() {
+            z += c * &self.private_keys[key_id] * compute::lambda(*key_id, signers);
         }
-        z
+
+        SignatureShare {
+            party_id: self.party_id,
+            z_i: z,
+            public_keys: self.public_keys.clone(),
+        }
     }
 }
 
 #[allow(non_snake_case)]
 pub struct SignatureAggregator {
     pub num_keys: usize,
-    pub num_parties: usize,
     pub threshold: usize,
-    pub A: Vec<PolyCommitment>, // outer vector is N-long, inner vector is T-long
-    pub B: Vec<Vec<PublicNonce>>, // outer vector is N-long, inner vector is T-long
     pub group_key: Point,       // the group's combined public key
-    pub public_keys: PubKeyMap, // the public key for each point
-    nonce_ctr: usize,
-    num_nonces: usize,
 }
 
 impl SignatureAggregator {
@@ -159,9 +169,8 @@ impl SignatureAggregator {
         num_keys: usize,
         num_parties: usize,
         threshold: usize,
-        A: Vec<PolyCommitment>,
-        B: Vec<Vec<PublicNonce>>,
-        public_keys: PubKeyMap,
+        A: Vec<PolyCommitment>, // one per party_id
+        _public_keys: PubKeyMap, // one per key_id
     ) -> Self {
         assert!(A.len() == num_parties);
         for A_i in &A {
@@ -174,22 +183,10 @@ impl SignatureAggregator {
         }
         println!("SA groupKey {}", key);
 
-        assert!(B.len() == num_parties);
-        let num_nonces = B[0].len();
-        for b in &B {
-            assert!(num_nonces == b.len());
-        }
-
         Self {
             num_keys: num_keys,
-            num_parties: num_parties,
             threshold: threshold,
-            A: A,
-            B: B,
             group_key: key,
-            public_keys: public_keys,
-            nonce_ctr: 0,
-            num_nonces: num_nonces,
         }
     }
 
@@ -197,55 +194,130 @@ impl SignatureAggregator {
     pub fn sign(
         &mut self,
         msg: &[u8],
-        nonces: &[PublicNonce], // for now duplicate for each key a party has
+        nonces: &[PublicNonce],
         sig_shares: &[SignatureShare],
     ) -> Signature {
-        let signers: Vec<usize> = sig_shares.iter().map(|ss| ss.id).collect();
+        let signers: Vec<usize> = sig_shares.iter().map(|ss| ss.party_id).collect();
         let (Ris, R) = compute::intermediate(msg, &signers, nonces);
-
         let mut z = Scalar::zero();
         let c = compute::challenge(&self.group_key, &R, &msg); // only needed for checking z_i
-        for i in sig_shares.len() {
+
+        for i in 0..sig_shares.len() {
+            let z_i = sig_shares[i].z_i;
             assert!(
-                let z_i = sig_shares[i].z_i;
                 z_i * G
-                    == Ris[&sig.party_id]
-                        + signers[&sig.party_id]
-                            .iter()
-                            .fold(Point::zero(), |p, k| p + compute::lambda(&k, signers)
+                    == Ris[i]
+                    + sig_shares
+                        .iter()
+                        .enumerate()
+                        .fold(Point::zero(), |p, (k,share)| p + compute::lambda(share.party_id, &signers)
                                 * c
-                                * self.public_keys[k])
+                                * share.public_keys[&k])
             );
-            z += sig.z_i;
+            z += z_i;
         }
-        self.update_nonce();
 
         let sig = Signature { R: R, z: z };
         assert!(sig.verify(&self.group_key, msg));
         sig
     }
+}
 
-    pub fn get_nonce_ctr(&self) -> usize {
-        self.nonce_ctr
-    }
+#[cfg(test)]
+mod tests {
+    use crate::common::{PolyCommitment, PublicNonce};
+    use crate::traits::Signer;
+    use crate::v2::SignatureShare;
+    use crate::v2;
 
-    fn update_nonce(&mut self) {
-        self.nonce_ctr += 1;
-        if self.nonce_ctr == self.num_nonces {
-            // TODO: Should this kick off the re-generation process?
-            println!("This is the last available nonce! Need to generate more!");
+    use hashbrown::HashMap;
+    use rand_core::{CryptoRng, OsRng, RngCore};
+
+    #[allow(non_snake_case)]
+    fn dkg<RNG: RngCore + CryptoRng>(
+        signers: &mut Vec<v2::Party>,
+        rng: &mut RNG,
+    ) -> Vec<PolyCommitment> {
+        let A: Vec<PolyCommitment> = signers
+            .iter()
+            .map(|s| s.get_poly_commitment(rng))
+            .collect();
+
+        // each party broadcasts their commitments
+        // these hashmaps will need to be serialized in tuples w/ the value encrypted
+        // Vec<(party_id, HashMap<key_id, Share>)>
+        let mut broadcast_shares = Vec::new();
+        for party in signers.iter() {
+            broadcast_shares.push((party.party_id, party.get_shares()));
         }
+
+        // each party collects its shares from the broadcasts
+        // maybe this should collect into a hashmap first?
+        for party in signers.iter_mut() {
+            let mut h = HashMap::new();
+            for key_id in party.key_ids.clone() {
+                let mut g = Vec::new();
+
+                for (id, shares) in &broadcast_shares {
+                    g.push((*id, shares[&key_id]));
+                }
+
+                h.insert(key_id, g);
+            }
+
+            party.compute_secret(h, &A);
+        }
+
+        A
+    }
+
+    // There might be a slick one-liner for this?
+    fn sign<RNG: RngCore + CryptoRng>(
+        msg: &[u8],
+        signers: &mut [v2::Party],
+        rng: &mut RNG,
+    ) -> (Vec<PublicNonce>, Vec<SignatureShare>) {
+        let party_ids: Vec<usize> = signers.iter().map(|s| s.party_id).collect();
+        let nonces: Vec<PublicNonce> = signers.iter_mut().map(|s| s.gen_nonce(rng)).collect();
+        let shares = signers
+            .iter()
+            .map(|s| s.sign(msg, &party_ids, &nonces))
+            .collect();
+
+        (nonces, shares)
     }
 
     #[allow(non_snake_case)]
-    pub fn set_party_nonces(&mut self, i: usize, B: Vec<PublicNonce>) {
-        self.B[i] = B;
-    }
+    #[test]
+    fn aggregator_sign() {
+        let mut rng = OsRng::default();
+        let msg = "It was many and many a year ago".as_bytes();
+        let N: usize = 10;
+        let T: usize = 7;
+        let party_key_ids: Vec<Vec<usize>> = [
+            [0, 1, 2].to_vec(),
+            [3, 4].to_vec(),
+            [5, 6, 7].to_vec(),
+            [8, 9].to_vec(),
+        ]
+        .to_vec();
+        let mut signers = party_key_ids
+            .iter().enumerate()
+            .map(|(pid, pkids)| v2::Party::new(pid, pkids, party_key_ids.len(), N, T, &mut rng))
+            .collect();
 
-    #[allow(non_snake_case)]
-    pub fn set_group_nonces(&mut self, B: Vec<Vec<PublicNonce>>) {
-        self.B = B;
-        self.nonce_ctr = 0;
-        self.num_nonces = self.B.len();
+        let A = dkg(&mut signers, &mut rng);
+
+        // signers [0,1,3] who have T keys
+        {
+            let mut signers = [signers[0].clone(), signers[1].clone(), signers[3].clone()].to_vec();
+            let mut sig_agg = v2::SignatureAggregator::new(N, T, A.clone());
+
+            let (nonces, sig_shares) = sign(&msg, &mut signers, &mut rng);
+            let sig = sig_agg.sign(&msg, &nonces, &sig_shares);
+
+            println!("Signature (R,z) = \n({},{})", sig.R, sig.z);
+            assert!(sig.verify(&sig_agg.key, &msg));
+        }
     }
 }

--- a/src/v2.rs
+++ b/src/v2.rs
@@ -195,8 +195,6 @@ impl SignatureAggregator {
         assert_eq!(nonces.len(), sig_shares.len());
 
         let signers: Vec<usize> = sig_shares.iter().map(|ss| ss.party_id).collect();
-        //println!("signers: {:?}\nnonces: {:?}", &signers, nonces);
-
         let (Ris, R) = compute::intermediate(msg, &signers, nonces);
         println!("aggre sign R {}", &R);
         let mut z = Scalar::zero();

--- a/src/v2.rs
+++ b/src/v2.rs
@@ -82,7 +82,7 @@ impl Party {
 
     pub fn get_shares(&self) -> HashMap<usize, Scalar> {
         let mut shares = HashMap::new();
-        for i in 0..self.num_keys as usize {
+        for i in self.num_keys {
             shares.insert(i, self.f.eval(compute::id(i)));
         }
         shares

--- a/src/v2.rs
+++ b/src/v2.rs
@@ -213,7 +213,7 @@ impl SignatureAggregator {
                     == Ris[i]
                         + sig_shares[i].public_keys.iter().fold(
                             Point::zero(),
-                            |p, (key_id, public_key)| p + compute::lambda(*key_id, &key_ids)
+                            |p, (key_id, public_key)| p + compute::lambda(*key_id, key_ids)
                                 * c
                                 * public_key
                         )

--- a/src/v2.rs
+++ b/src/v2.rs
@@ -1,14 +1,14 @@
-use num_traits::{One, Zero};
+use num_traits::Zero;
 use polynomial::Polynomial;
 use rand_core::{CryptoRng, RngCore};
 use secp256k1_math::{
     point::{Point, G},
     scalar::Scalar,
 };
-use sha3::{Digest, Sha3_256};
 
+use crate::common::{Nonce, PolyCommitment, PublicNonce, Signature, SignatureShare};
+use crate::compute;
 use crate::schnorr::ID;
-use crate::util::hash_to_scalar;
 use crate::vss::VSS;
 
 use hashbrown::{HashMap, HashSet};
@@ -16,117 +16,6 @@ use hashbrown::{HashMap, HashSet};
 pub type PubKeyMap = HashMap<usize, Point>;
 pub type PrivKeyMap = HashMap<usize, Scalar>;
 pub type SelectedSigners = HashMap<usize, HashSet<usize>>;
-
-#[allow(non_snake_case)]
-pub struct PolyCommitment {
-    pub party_id: ID,
-    pub A: Vec<Point>,
-}
-
-impl PolyCommitment {
-    pub fn verify(&self) -> bool {
-        self.party_id.verify(&self.A[0])
-    }
-}
-
-#[derive(Clone)]
-pub struct Nonce {
-    d: Scalar,
-    e: Scalar,
-}
-
-#[derive(Clone)]
-#[allow(non_snake_case)]
-pub struct PublicNonce {
-    pub D: Point,
-    pub E: Point,
-}
-
-impl PublicNonce {
-    pub fn from(n: &Nonce) -> Self {
-        Self {
-            D: &n.d * G,
-            E: &n.e * G,
-        }
-    }
-}
-
-// The SA should get that as usual
-pub struct SignatureShare {
-    pub party_id: usize,
-    pub z_i: Scalar,
-}
-
-#[allow(non_snake_case)]
-fn compute_binding(party_id: &Scalar, B: &Vec<PublicNonce>, msg: &[u8]) -> Scalar {
-    let mut hasher = Sha3_256::new();
-
-    hasher.update(party_id.as_bytes());
-    for b in B {
-        hasher.update(b.D.compress().as_bytes());
-        hasher.update(b.E.compress().as_bytes());
-    }
-    hasher.update(msg);
-
-    hash_to_scalar(&mut hasher)
-}
-
-#[allow(non_snake_case)]
-fn compute_challenge(publicKey: &Point, R: &Point, msg: &[u8]) -> Scalar {
-    let mut hasher = Sha3_256::new();
-
-    hasher.update(publicKey.compress().as_bytes());
-    hasher.update(R.compress().as_bytes());
-    hasher.update(msg);
-
-    hash_to_scalar(&mut hasher)
-}
-
-fn lambda(i: &usize, signers: &SelectedSigners) -> Scalar {
-    let mut lambda = Scalar::one();
-    let i_scalar = id_to_scalar(i);
-    for (_, h) in signers {
-        for j in h {
-            if i != j {
-                let j_scalar = id_to_scalar(j);
-                lambda *= j_scalar / (j_scalar - i_scalar);
-            }
-        }
-    }
-    lambda
-}
-
-// Is this the best way to return these values?
-// TODO: this fn needs a better name
-#[allow(non_snake_case)]
-fn compute_intermediate_values(
-    signers: &SelectedSigners, // only the keys are needed
-    B: &Vec<Vec<PublicNonce>>,
-    index: usize,
-    msg: &[u8],
-) -> (Vec<PublicNonce>, HashMap<usize, Point>, Point) {
-    let mut signer_vec = Vec::from_iter(signers.keys());
-    signer_vec.sort();
-    let B = signer_vec
-        .iter()
-        .map(|&party_id| B[*party_id][index].clone())
-        .collect();
-    let rho: Vec<Scalar> = signer_vec
-        .iter()
-        .map(|&party_id| compute_binding(&id_to_scalar(&party_id), &B, &msg))
-        .collect();
-
-    let mut Ris = HashMap::new();
-    for i in 0..signer_vec.len() {
-        Ris.insert(*signer_vec[i], &B[i].D + &rho[i] * &B[i].E);
-    }
-    let R = Ris.values().fold(Point::zero(), |R, R_i| R + R_i);
-    (B, Ris, R)
-}
-
-fn id_to_scalar(id: &usize) -> Scalar {
-    Scalar::from((id + 1) as u32)
-}
 
 #[derive(Clone)]
 #[allow(non_snake_case)]
@@ -139,8 +28,7 @@ pub struct Party {
     f: Polynomial<Scalar>, // one poly per party to simulate the sum of all their polys
     private_keys: PrivKeyMap, // key is key_id
     group_key: Point,
-    nonces: Vec<Nonce>,
-    B: Vec<Vec<PublicNonce>>, // received from other parties
+    nonce: Nonce,
 }
 
 impl Party {
@@ -162,50 +50,33 @@ impl Party {
             private_keys: PrivKeyMap::new(),
             public_keys: PubKeyMap::new(),
             group_key: Point::zero(),
-            nonces: Vec::new(),
-            B: Vec::new(),
+            nonce: Nonce::zero(),
         }
     }
 
-    pub fn gen_nonces<RNG: RngCore + CryptoRng>(
+    pub fn gen_nonce<RNG: RngCore + CryptoRng>(
         &mut self,
-        num_nonces: u32,
         rng: &mut RNG,
-    ) -> Vec<PublicNonce> {
-        self.nonces = (0..num_nonces)
-            .map(|_| Nonce {
-                d: Scalar::random(rng),
-                e: Scalar::random(rng),
-            })
-            .collect();
-        self.nonces.iter().map(|n| PublicNonce::from(n)).collect()
-    }
+    ) -> PublicNonce {
+        self.nonce = Nonce::random(rng);
 
-    #[allow(non_snake_case)]
-    pub fn set_group_nonces(&mut self, B: Vec<Vec<PublicNonce>>) {
-        self.B = B;
-    }
-
-    // Warning: This function assumes that B already exists - it's just for resetting
-    #[allow(non_snake_case)]
-    pub fn set_party_nonces(&mut self, party_id: usize, B: Vec<PublicNonce>) {
-        self.B[party_id] = B;
+        PublicNonce::from(&self.nonce)
     }
 
     #[allow(non_snake_case)]
     pub fn get_poly_commitment<RNG: RngCore + CryptoRng>(&self, rng: &mut RNG) -> PolyCommitment {
         PolyCommitment {
-            party_id: ID::new(&id_to_scalar(&self.party_id), &self.f.data()[0], rng),
+            id: ID::new(&self.id(), &self.f.data()[0], rng),
             A: (0..self.f.data().len())
                 .map(|i| &self.f.data()[i] * G)
                 .collect(),
         }
     }
 
-    pub fn get_shares(&self) -> Vec<(usize, Scalar)> {
-        let mut shares = Vec::new();
+    pub fn get_shares(&self) -> HashMap<usize, Scalar> {
+        let mut shares = HashMap::new();
         for i in 0..self.num_keys as usize {
-            shares.push((i, self.f.eval(id_to_scalar(&i))));
+            shares.insert(i, self.f.eval(compute::id(i)));
         }
         shares
     }
@@ -235,7 +106,7 @@ impl Party {
                 assert!(
                     s * G
                         == (0..Ai.A.len()).fold(Point::zero(), |s, j| s
-                            + (id_to_scalar(key_id) ^ j) * Ai.A[j])
+                            + (compute::id(*key_id) ^ j) * Ai.A[j])
                 );
                 self.private_keys
                     .insert(*key_id, self.private_keys[key_id] + s);
@@ -251,36 +122,21 @@ impl Party {
         &self.public_keys
     }
 
+    pub fn id(&self) -> Scalar {
+        compute::id(self.party_id)
+    }
+
+
     #[allow(non_snake_case)]
-    pub fn sign(&self, msg: &[u8], signers: &SelectedSigners, nonce_index: usize) -> Scalar {
-        let (B, _R_vec, R) = compute_intermediate_values(&signers, &self.B, nonce_index, &msg);
-        let c = compute_challenge(&self.group_key, &R, &msg);
-        let nonce = &self.nonces[nonce_index]; // TODO: needs to check that index exists
+    pub fn sign(&self, msg: &[u8], signers: &[usize], nonces: &[PublicNonce]) -> Scalar {
+        let (_R_vec, R) = compute::intermediate(msg, signers, nonces);
+        let c = compute::challenge(&self.group_key, &R, &msg);
 
         let mut z = &nonce.d + &nonce.e * compute_binding(&id_to_scalar(&self.party_id), &B, &msg);
         for key_id in signers[&self.party_id].iter() {
             z += c * &self.private_keys[key_id] * lambda(&key_id, signers);
         }
         z
-    }
-}
-
-#[allow(non_snake_case)]
-pub struct Signature {
-    pub R: Point,
-    pub z: Scalar,
-}
-
-impl Signature {
-    // verify: R' = z * G + -c * publicKey, pass if R' == R
-    #[allow(non_snake_case)]
-    pub fn verify(&self, public_key: &Point, msg: &[u8]) -> bool {
-        let c = compute_challenge(&public_key, &self.R, &msg);
-        let R = &self.z * G + (-c) * public_key;
-
-        println!("Verification R = {}", R);
-
-        R == self.R
     }
 }
 
@@ -341,20 +197,22 @@ impl SignatureAggregator {
     pub fn sign(
         &mut self,
         msg: &[u8],
-        sig_shares: &[SignatureShare], // one per party and each contains vectors for all their pts
-        signers: &SelectedSigners,     // the list of party_ids
+        nonces: &[PublicNonce], // for now duplicate for each key a party has
+        sig_shares: &[SignatureShare],
     ) -> Signature {
-        let (_B, Ris, R) = compute_intermediate_values(&signers, &self.B, self.nonce_ctr, &msg);
+        let signers: Vec<usize> = sig_shares.iter().map(|ss| ss.id).collect();
+        let (Ris, R) = compute::intermediate(msg, &signers, nonces);
 
         let mut z = Scalar::zero();
-        let c = compute_challenge(&self.group_key, &R, &msg); // only needed for checking z_i
-        for sig in sig_shares {
+        let c = compute::challenge(&self.group_key, &R, &msg); // only needed for checking z_i
+        for i in sig_shares.len() {
             assert!(
-                sig.z_i * G
+                let z_i = sig_shares[i].z_i;
+                z_i * G
                     == Ris[&sig.party_id]
                         + signers[&sig.party_id]
                             .iter()
-                            .fold(Point::zero(), |p, k| p + lambda(&k, signers)
+                            .fold(Point::zero(), |p, k| p + compute::lambda(&k, signers)
                                 * c
                                 * self.public_keys[k])
             );


### PR DESCRIPTION
This change updates the v2 code to use the common crate and ephemeral nonces.  It also updates the v2 test code to use the v1 framework, which has discrete ```dkg``` and ```sign``` functions.  There are also a lot of CI improvements.